### PR TITLE
Remove callbacks and move code out of primary protocol parsing

### DIFF
--- a/DcsBios.h
+++ b/DcsBios.h
@@ -1,7 +1,6 @@
 #ifndef __DCSBIOS_H
 #define __DCSBIOS_H
 
-#include "Arduino.h"
 #include "Protocol.h"
 #include "Buttons.h"
 #include "Switches.h"

--- a/ExportStreamListener.h
+++ b/ExportStreamListener.h
@@ -38,8 +38,6 @@ namespace DcsBios {
 				if ((address >= address_) && (endAddress_ > address)) {
 					unsigned int index = address - address_;
 					buffer[index] = ((char*)&value)[0];
-					// No reason to check index here. We allocate an extra byte for zero termination
-					// and Export protocol pads odd length strings with a 0.
 					index++;
 					if (LENGTH > index) {
 						buffer[index] = ((char*)&value)[1];

--- a/ExportStreamListener.h
+++ b/ExportStreamListener.h
@@ -35,33 +35,67 @@ namespace DcsBios {
 	class StringBuffer : ExportStreamListener {
 		private:
 			void onDcsBiosWrite(unsigned int address, unsigned int value) {
-				if ((address >= address_) && (address_ + LENGTH > address)) {
-					setChar(address - address_, ((char*)&value)[0]);
-				if (address_ + LENGTH > (address+1))
-					setChar(address - address_ + 1, ((char*)&value)[1]);
-				}
-				if (address == 0xfffe) {
-					if (dirty_) {
-						callback_(buffer);
-						dirty_ = false;
+				if ((address >= address_) && (endAddress_ > address)) {
+					unsigned int index = address - address_;
+					buffer[index] = ((char*)&value)[0];
+					// No reason to check index here. We allocate an extra byte for zero termination
+					// and Export protocol pads odd length strings with a 0.
+					index++;
+					if (LENGTH > index) {
+						buffer[index] = ((char*)&value)[1];
 					}
+					// No need to compare existing buffer with current value.  We never get to this
+					// point unless the sim has sent a change.
+					dirty_ = true;
 				}
-			}
-			void setChar(unsigned int index, unsigned char value) {
-				if (buffer[index] == value) return;
-				buffer[index] = value;
-				dirty_ = true;
 			}
 			unsigned int address_;
+			unsigned int endAddress_;
 			bool dirty_;
-			void (*callback_)(char*);
 		public:
 			char buffer[LENGTH+1];
-			StringBuffer(unsigned int address, void (*callback)(char*)) {
-				callback_ = callback;
+			StringBuffer(unsigned int address) {
 				dirty_ = false;
 				address_ = address;
+				// Move calculating end address into startup.  Timing for
+				// parsing loop is more critical than the extra 2 bytes of ram.
+				endAddress_ = address+LENGTH;
 				memset(buffer, '\0', LENGTH+1);
+			}
+			// Replace callback with external dirty flag.  Callbacks are
+			// not safe inside protcol parsing due to timing criticallity.
+			bool isDirty() {
+				return dirty_;
+			}
+			void clearDirty() {
+				dirty_ = false;
+			}
+	};
+
+	class IntegerBuffer : ExportStreamListener {
+		private:
+			void onDcsBiosWrite(unsigned int address, unsigned int value) {
+				if (address == address_) {
+					data = (value & mask_) >> shift_;
+				}
+			}
+			unsigned int address_;
+			unsigned int mask_;
+			unsigned char shift_;
+			bool dirty_;
+		public:
+			int data;
+			IntegerBuffer(unsigned int address, unsigned int mask, unsigned char shift) {
+				dirty_ = false;
+				address_ = address;
+				mask_ = mask;
+				shift_ = shift;
+			}
+			bool isDirty() {
+				return dirty_;
+			}
+			void clearDirty() {
+				dirty_ = false;
 			}
 	};
 	

--- a/Leds.cpp
+++ b/Leds.cpp
@@ -3,21 +3,17 @@
 
 namespace DcsBios {
 
-	LED::LED(unsigned int address, unsigned int mask, char pin) {
-		address_ = address;
-		mask_ = mask;
+	LED::LED(unsigned int address, unsigned int mask, char pin) : IntegerBuffer(address, mask, 0) {
 		pin_ = pin;
 		pinMode(pin_, OUTPUT);
 		digitalWrite(pin_, LOW);
 	}
-	void LED::onDcsBiosWrite(unsigned int address, unsigned int value) {
-		if (address_ == address) {
-			if (value & mask_) {
-				digitalWrite(pin_, HIGH);
-			} else {
-				digitalWrite(pin_, LOW);
-			}
-		}
+	void LED::onDcsBiosFrameSync() {
+		if (data) {
+			digitalWrite(pin_, HIGH);
+		} else {
+			digitalWrite(pin_, LOW);
+		}			
 	}
 
 }

--- a/Leds.h
+++ b/Leds.h
@@ -6,12 +6,10 @@
 
 namespace DcsBios {
 
-	class LED : ExportStreamListener {
+	class LED : IntegerBuffer {
 		private:
-			void onDcsBiosWrite(unsigned int address, unsigned int value);
+			void onDcsBiosFrameSync();
 			unsigned char pin_;
-			unsigned int address_;
-			unsigned int mask_;
 		public:
 			LED(unsigned int address, unsigned int mask, char pin);
 	};

--- a/Protocol.h
+++ b/Protocol.h
@@ -1,6 +1,9 @@
 #ifndef __DCSBIOS_PROTOCOL_H
 #define __DCSBIOS_PROTOCOL_H
 
+void onDcsBiosWrite(unsigned int address, unsigned int value);
+void onDcsBiosFrameSync();
+
 #define DCSBIOS_STATE_WAIT_FOR_SYNC 0
 #define DCSBIOS_STATE_ADDRESS_LOW 1
 #define DCSBIOS_STATE_ADDRESS_HIGH 2
@@ -8,8 +11,6 @@
 #define DCSBIOS_STATE_COUNT_HIGH 4
 #define DCSBIOS_STATE_DATA_LOW 5
 #define DCSBIOS_STATE_DATA_HIGH 6
-
-void onDcsBiosWrite(unsigned int address, unsigned int value);
 
 namespace DcsBios {
 

--- a/Servos.cpp
+++ b/Servos.cpp
@@ -3,18 +3,18 @@
 
 namespace DcsBios {
 
-	ServoOutput::ServoOutput(unsigned int address, char pin, int minPulseWidth, int maxPulseWidth) {
-		address_ = address;
+	ServoOutput::ServoOutput(unsigned int address, char pin, int minPulseWidth, int maxPulseWidth) : IntegerBuffer (address, 0xffff, 0) {
 		pin_ = pin;
 		minPulseWidth_ = minPulseWidth;
 		maxPulseWidth_ = maxPulseWidth;
 	}
-	void ServoOutput::onDcsBiosWrite(unsigned int address, unsigned int value) {
-		if (address_ == address) {
-			if (!servo_.attached())
-				servo_.attach(pin_, minPulseWidth_, maxPulseWidth_);
-			servo_.writeMicroseconds(map(value, 0, 65535, minPulseWidth_, maxPulseWidth_));
-		}
+	ServoOutput::ServoOutput(unsigned int address, char pin) : IntegerBuffer (address, 0xffff, 0) {
+		ServoOutput(address, pin, 544, 2400);
+	}
+	void ServoOutput::onDcsBiosFrameSync() {
+		if (!servo_.attached())
+			servo_.attach(pin_, minPulseWidth_, maxPulseWidth_);
+		servo_.writeMicroseconds(map(data, 0, 65535, minPulseWidth_, maxPulseWidth_));
 	}
 
 }

--- a/Servos.h
+++ b/Servos.h
@@ -6,17 +6,16 @@
 #include <Servo.h>
 
 namespace DcsBios {
-	class ServoOutput : ExportStreamListener {
+	class ServoOutput : IntegerBuffer {
 		private:
-			void onDcsBiosWrite(unsigned int address, unsigned int value);
+			void onDcsBiosFrameSync();
 			Servo servo_;
-			unsigned int address_;
 			char pin_;
 			int minPulseWidth_;
 			int maxPulseWidth_;
 		public:
 			ServoOutput(unsigned int address, char pin, int minPulseWidth, int maxPulseWidth);
-			ServoOutput(unsigned int address, char pin) { ServoOutput(address, pin, 544, 2400); }
+			ServoOutput(unsigned int address, char pin);
 	};
 }
 


### PR DESCRIPTION
Moved all output code to onFrameSync and moved onFrameSync over to end of frame so long executing updates happen during the 30ms between frames.

This resovles #4 