### PR TITLE
Added configurable deadband to potentiometer class

### DIFF
--- a/ExportStreamListener.h
+++ b/ExportStreamListener.h
@@ -71,10 +71,14 @@ namespace DcsBios {
 	};
 
 	class IntegerBuffer : ExportStreamListener {
-		private:
+		protected:
 			void onDcsBiosWrite(unsigned int address, unsigned int value) {
 				if (address == address_) {
-					data = (value & mask_) >> shift_;
+					unsigned int newValue = (value & mask_) >> shift_;
+					if( newValue != data ) {
+						data = newValue;
+						dirty_ = true;
+					}
 				}
 			}
 			unsigned int address_;
@@ -97,6 +101,31 @@ namespace DcsBios {
 			}
 	};
 	
+	class MappedIntegerBuffer : public IntegerBuffer {
+		private:
+			void onDcsBiosWrite(unsigned int address, unsigned int value) {
+				if (address == address_) {
+					unsigned int newValue = map(( value & mask_ ) >> shift_, fromLo_, fromHi_, toLo_, toHi_);
+					if(newValue != data) {
+						data = newValue;
+						dirty_ = true;
+					}
+				}
+			}
+			unsigned int fromLo_;
+			unsigned int fromHi_;
+			unsigned int toLo_;
+			unsigned int toHi_;
+		public:
+			MappedIntegerBuffer(unsigned int address, unsigned int mask, unsigned char shift, unsigned int fromLo=0, unsigned fromHi=65535, unsigned int toLo=0, unsigned int toHi=65535) :
+				IntegerBuffer(address, mask, shift) {
+				fromLo_ = fromLo;
+				fromHi_ = fromHi;
+				toLo_ = toLo;
+				toHi_ = toHi;
+			}
+	};
+
 }
 
 #endif

--- a/ExportStreamListener.h
+++ b/ExportStreamListener.h
@@ -43,7 +43,8 @@ namespace DcsBios {
 						buffer[index] = ((char*)&value)[1];
 					}
 					// No need to compare existing buffer with current value.  We never get to this
-					// point unless the sim has sent a change.
+					// point unless the sim has sent a change.				
+					// OH: Is this true - I understood AcftName is always transmitted at the start of the frame?
 					dirty_ = true;
 				}
 			}
@@ -70,7 +71,7 @@ namespace DcsBios {
 			}
 	};
 
-	class IntegerBuffer : ExportStreamListener {
+	class IntegerData : ExportStreamListener {
 		protected:
 			void onDcsBiosWrite(unsigned int address, unsigned int value) {
 				if (address == address_) {
@@ -87,7 +88,7 @@ namespace DcsBios {
 			bool dirty_;
 		public:
 			int data;
-			IntegerBuffer(unsigned int address, unsigned int mask, unsigned char shift) {
+			IntegerData(unsigned int address, unsigned int mask, unsigned char shift) {
 				dirty_ = false;
 				address_ = address;
 				mask_ = mask;
@@ -101,7 +102,7 @@ namespace DcsBios {
 			}
 	};
 	
-	class MappedIntegerBuffer : public IntegerBuffer {
+	class MappedIntegerData : public IntegerData {
 		private:
 			void onDcsBiosWrite(unsigned int address, unsigned int value) {
 				if (address == address_) {
@@ -117,8 +118,8 @@ namespace DcsBios {
 			unsigned int toLo_;
 			unsigned int toHi_;
 		public:
-			MappedIntegerBuffer(unsigned int address, unsigned int mask, unsigned char shift, unsigned int fromLo=0, unsigned fromHi=65535, unsigned int toLo=0, unsigned int toHi=65535) :
-				IntegerBuffer(address, mask, shift) {
+			MappedIntegerData(unsigned int address, unsigned int mask, unsigned char shift, unsigned int fromLo=0, unsigned fromHi=65535, unsigned int toLo=0, unsigned int toHi=65535) :
+				IntegerData(address, mask, shift) {
 				fromLo_ = fromLo;
 				fromHi_ = fromHi;
 				toLo_ = toLo;

--- a/Leds.cpp
+++ b/Leds.cpp
@@ -3,7 +3,7 @@
 
 namespace DcsBios {
 
-	LED::LED(unsigned int address, unsigned int mask, char pin) : IntegerBuffer(address, mask, 0) {
+	LED::LED(unsigned int address, unsigned int mask, char pin) : IntegerData(address, mask, 0) {
 		pin_ = pin;
 		pinMode(pin_, OUTPUT);
 		digitalWrite(pin_, LOW);

--- a/Leds.h
+++ b/Leds.h
@@ -6,7 +6,7 @@
 
 namespace DcsBios {
 
-	class LED : IntegerBuffer {
+	class LED : IntegerData {
 		private:
 			void onDcsBiosFrameSync();
 			unsigned char pin_;

--- a/Potentiometers.cpp
+++ b/Potentiometers.cpp
@@ -3,15 +3,23 @@
 
 namespace DcsBios {
 	
-	Potentiometer::Potentiometer(char* msg, char pin, unsigned int deadband) {
+	Potentiometer::Potentiometer(char* msg, char pin, unsigned int deadband, bool invert) {
 		msg_ = msg;
 		pin_ = pin;
 		deadBand_ = deadband;
+		invert_ = invert;
 		pinMode(pin_, INPUT);
-		lastState_ = map(analogRead(pin_), 0, 1023, 0, 65535);
+		if( !invert_ )
+			lastState_ = map(analogRead(pin_), 0, 1023, 0, 65535);
+		else
+			lastState_ = map(1023-analogRead(pin_), 0, 1023, 0, 65535);			
 	}
 	void Potentiometer::pollInput() {
-		unsigned int state = map(analogRead(pin_), 0, 1023, 0, 65535);
+		unsigned int state;
+		if( !invert_ )
+			state = map(analogRead(pin_), 0, 1023, 0, 65535);
+		else
+			state = map(1023-analogRead(pin_), 0, 1023, 0, 65535);			
 
 		// Work out the clipped lower/upper boundaries and clip them to the limits
 		unsigned int lowerBound = ( lastState_ < deadBand_ )?0:( lastState_-deadBand_ );

--- a/Potentiometers.cpp
+++ b/Potentiometers.cpp
@@ -3,20 +3,26 @@
 
 namespace DcsBios {
 	
-	Potentiometer::Potentiometer(char* msg, char pin) {
+	Potentiometer::Potentiometer(char* msg, char pin, unsigned int deadband) {
 		msg_ = msg;
 		pin_ = pin;
+		deadBand_ = deadband;
 		pinMode(pin_, INPUT);
 		lastState_ = map(analogRead(pin_), 0, 1023, 0, 65535);
 	}
 	void Potentiometer::pollInput() {
 		unsigned int state = map(analogRead(pin_), 0, 1023, 0, 65535);
-		if (state != lastState_) {
+
+		// Work out the clipped lower/upper boundaries and clip them to the limits
+		unsigned int lowerBound = ( lastState_ < deadBand_ )?0:( lastState_-deadBand_ );
+		unsigned int upperBound = ( lastState_ > ( 65535 - deadBand_ ))?65535:( lastState_+deadBand_ );
+		
+		if (( state < lowerBound ) || ( state > upperBound )) {
 			char buf[6];
 			utoa(state, buf, 10);
 			sendDcsBiosMessage(msg_, buf);
+			lastState_ = state;
 		}
-		lastState_ = state;
 	}
 
 }

--- a/Potentiometers.h
+++ b/Potentiometers.h
@@ -12,8 +12,9 @@ namespace DcsBios {
 			char* msg_;
 			char pin_;
 			unsigned int lastState_;
+			unsigned int deadBand_;
 		public:
-			Potentiometer(char* msg, char pin);
+			Potentiometer(char* msg, char pin, unsigned int deadband=0);
 	};
 
 }

--- a/Potentiometers.h
+++ b/Potentiometers.h
@@ -13,8 +13,9 @@ namespace DcsBios {
 			char pin_;
 			unsigned int lastState_;
 			unsigned int deadBand_;
+			bool	invert_;
 		public:
-			Potentiometer(char* msg, char pin, unsigned int deadband=0);
+			Potentiometer(char* msg, char pin, unsigned int deadband=0, bool invert=false);
 	};
 
 }

--- a/Servos.cpp
+++ b/Servos.cpp
@@ -3,12 +3,12 @@
 
 namespace DcsBios {
 
-	ServoOutput::ServoOutput(unsigned int address, char pin, int minPulseWidth, int maxPulseWidth) : IntegerBuffer (address, 0xffff, 0) {
+	ServoOutput::ServoOutput(unsigned int address, char pin, int minPulseWidth, int maxPulseWidth) : IntegerData (address, 0xffff, 0) {
 		pin_ = pin;
 		minPulseWidth_ = minPulseWidth;
 		maxPulseWidth_ = maxPulseWidth;
 	}
-	ServoOutput::ServoOutput(unsigned int address, char pin) : IntegerBuffer (address, 0xffff, 0) {
+	ServoOutput::ServoOutput(unsigned int address, char pin) : IntegerData (address, 0xffff, 0) {
 		ServoOutput(address, pin, 544, 2400);
 	}
 	void ServoOutput::onDcsBiosFrameSync() {

--- a/Servos.h
+++ b/Servos.h
@@ -6,7 +6,7 @@
 #include <Servo.h>
 
 namespace DcsBios {
-	class ServoOutput : IntegerBuffer {
+	class ServoOutput : IntegerData {
 		private:
 			void onDcsBiosFrameSync();
 			Servo servo_;

--- a/examples/StringBufferLCD/StringBufferLCD.ino
+++ b/examples/StringBufferLCD/StringBufferLCD.ino
@@ -1,8 +1,14 @@
 #include <DcsBios.h>
 #include <Servo.h>
+#include <LiquidCrystal.h>
 
 /**** Make your changes after this line ****/
 
+// LCD Display
+LiquidCrystal lcd(22, 24, 26, 28, 30, 32);
+
+// Huey Radar Alt
+DcsBios::StringBuffer<4> raltDisplayBuffer(0x14aa);
 
 /**** In most cases, you do not have to change anything below this line ****/
 
@@ -10,7 +16,12 @@
 DcsBios::ProtocolParser parser;
 
 void setup() {
-  Serial.begin(250000);
+  Serial.begin(500000);
+  
+  // Set up the LCD
+  lcd.clear();
+  lcd.setCursor(0,0);
+  lcd.print("ALT:");
 }
 
 /*
@@ -62,5 +73,10 @@ Use this to handle object updates which are not covered by the
 DcsBios Arduino library (e.g. displays).
 */
 void onDcsBiosFrameSync() {
-
+  // Radar Alt
+  if(raltDisplayBuffer.isDirty()) {
+    lcd.setCursor(4,0);
+    lcd.print(raltDisplayBuffer.buffer);
+    raltDisplayBuffer.clearDirty();
+  }
 }

--- a/examples/StringBufferLCD/StringBufferLCD.ino
+++ b/examples/StringBufferLCD/StringBufferLCD.ino
@@ -16,7 +16,7 @@ DcsBios::StringBuffer<4> raltDisplayBuffer(0x14aa);
 DcsBios::ProtocolParser parser;
 
 void setup() {
-  Serial.begin(500000);
+  Serial.begin(250000);
   
   // Set up the LCD
   lcd.clear();


### PR DESCRIPTION
The Potentiometer constructor provides for an optional "deadband"
argument.  Updates will only be sent if the new value falls outside +/-
this deadband value.