### PR TITLE
Added an inverted potentiometer class

### DIFF
--- a/src/DcsBios.h
+++ b/src/DcsBios.h
@@ -105,6 +105,7 @@ do not come with their own build system, we are just putting everything into the
 #include "internal/Switches.h"
 #include "internal/Encoders.h"
 #include "internal/Potentiometers.h"
+#include "internal/Potentiometers_Inverted.h"
 #include "internal/Leds.h"
 #include "internal/Servos.h"
 

--- a/src/internal/Potentiometers_Inverted.h
+++ b/src/internal/Potentiometers_Inverted.h
@@ -1,0 +1,51 @@
+#ifndef __DCSBIOS_POTS_INV_H
+#define __DCSBIOS_POTS_INV_H
+
+#include <math.h>
+#include "Arduino.h"
+#include "PollingInput.h"
+
+namespace DcsBios {
+	template <unsigned int pollInterval = 5, unsigned int hysteresis = 128, unsigned int ewma_divisor = 5>
+	class PotentiometerInvEWMA : PollingInput {
+		private:
+			void pollInput() {
+				unsigned char now = (unsigned char)millis();
+				if ((unsigned char)(now - lastPollTime_) < pollInterval) return;
+				lastPollTime_ = now;
+				
+				unsigned int state = map(analogRead(pin_), 1023, 0, 0, 65535);
+				accumulator += ((float)state - accumulator) / (float)ewma_divisor;
+				state = (unsigned int)accumulator;
+				
+				if (((lastState_ > state && (lastState_ - state > hysteresis)))
+				|| ((state > lastState_) && (state - lastState_ > hysteresis))
+				|| ((state > (65535 - hysteresis) && state > lastState_))
+				|| ((state < hysteresis && state < lastState_))
+				) {
+					char buf[6];
+					utoa(state, buf, 10);
+					if (tryToSendDcsBiosMessage(msg_, buf))
+						lastState_ = state;
+				}
+			}
+			const char* msg_;
+			char pin_;
+			unsigned int lastState_;
+			float accumulator;
+			unsigned char lastPollTime_;
+			
+		public:
+			PotentiometerInvEWMA(const char* msg, char pin) {
+				msg_ = msg;
+				pin_ = pin;
+				pinMode(pin_, INPUT);
+				lastState_ = (float)map(analogRead(pin_), 0, 1023, 0, 65535);
+				lastPollTime_ = (unsigned char)millis();
+			}
+	};
+
+	typedef PotentiometerInvEWMA<> InvertedPotentiometer;	
+}
+
+#endif


### PR DESCRIPTION
This class will allow users who have wired their potentiometers the wrong way round to simply invert the input in code, rather than having to re-solder everything the other way around. For example, it is called in your Arduino sketch as follows: `DcsBios::PotentiometerInvEWMA<5, 128, 5> floodDimmer("FLOOD_DIMMER", FLOOD_LIGHT_PIN);`